### PR TITLE
Add Story Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
-{ "name": "chainletter",
+{
+  "name": "chainletter",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "react-scripts start",
+    "start": "npm i && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/src/components/organisms/Modal.js
+++ b/src/components/organisms/Modal.js
@@ -17,6 +17,7 @@ const Modal = ({
     e.preventDefault();
     submitHandler(e);
   };
+
   const handleCancel = () => {
     cancelHandler();
   };

--- a/src/components/organisms/Nav.js
+++ b/src/components/organisms/Nav.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuthContext } from '../../contexts/AuthContext';
 import Button from '../atoms/Button';
+// import AddStory from '../templates/AddStory';
 import Modal from './Modal';
 import './Nav.scss';
 
@@ -19,6 +20,7 @@ const Nav = () => {
     signup,
   } = useAuthContext();
   const [modalState, setModalState] = useState(modalStates.closed);
+  const [isAddingStory, setIsAddingStory] = useState(false);
 
   // const handleModalState = (e) => setModalState(e.value);
 
@@ -44,13 +46,35 @@ const Nav = () => {
             variant="text"
             text="Logout"
           />
-          <Link to="/link">
-            <Button
-              type="button"
-              variant="primary"
-              text="+"
-            />
-          </Link>
+          <Button
+            type="button"
+            variant="primary"
+            text="+"
+            clickHandler={() => setIsAddingStory(true)}
+          />
+          { isAddingStory && (
+            <Modal
+              title="Create New Story Link"
+              subTitle="write the first lines of a brand new story"
+              confirmText="Submit Story"
+              canCancel
+              submitHandler={() => {}}
+              cancelHandler={() => setIsAddingStory(false)}
+            >
+              <label htmlFor="story-add-title">
+                <div>
+                  Title
+                </div>
+                <input id="story-add-title" type="text" name="title" />
+              </label>
+              <label htmlFor="story-add-content">
+                <div>
+                  Story
+                </div>
+                <textarea id="story-add-content" type="password" name="content" />
+              </label>
+            </Modal>
+          ) }
         </>
       );
     }

--- a/src/components/organisms/Nav.js
+++ b/src/components/organisms/Nav.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuthContext } from '../../contexts/AuthContext';
 import Button from '../atoms/Button';
-// import AddStory from '../templates/AddStory';
+import AddStory from '../templates/AddStory';
 import Modal from './Modal';
 import './Nav.scss';
 
@@ -21,8 +21,6 @@ const Nav = () => {
   } = useAuthContext();
   const [modalState, setModalState] = useState(modalStates.closed);
   const [isAddingStory, setIsAddingStory] = useState(false);
-
-  // const handleModalState = (e) => setModalState(e.value);
 
   const handleLogin = (e) => {
     const { email, password } = e.target.elements;
@@ -52,29 +50,7 @@ const Nav = () => {
             text="+"
             clickHandler={() => setIsAddingStory(true)}
           />
-          { isAddingStory && (
-            <Modal
-              title="Create New Story Link"
-              subTitle="write the first lines of a brand new story"
-              confirmText="Submit Story"
-              canCancel
-              submitHandler={() => {}}
-              cancelHandler={() => setIsAddingStory(false)}
-            >
-              <label htmlFor="story-add-title">
-                <div>
-                  Title
-                </div>
-                <input id="story-add-title" type="text" name="title" />
-              </label>
-              <label htmlFor="story-add-content">
-                <div>
-                  Story
-                </div>
-                <textarea id="story-add-content" type="password" name="content" />
-              </label>
-            </Modal>
-          ) }
+          { isAddingStory && <AddStory toggleModal={setIsAddingStory} />}
         </>
       );
     }

--- a/src/components/organisms/Nav.js
+++ b/src/components/organisms/Nav.js
@@ -22,18 +22,29 @@ const Nav = () => {
   const [modalState, setModalState] = useState(modalStates.closed);
   const [isAddingStory, setIsAddingStory] = useState(false);
 
-  const handleLogin = (e) => {
-    const { email, password } = e.target.elements;
+  /**
+   * Take values from form to attempt a login
+   * @param {Object} event
+   */
+  const handleLogin = (event) => {
+    const { email, password } = event.target.elements;
     login(email.value, password.value);
     setModalState(modalStates.closed);
   };
 
-  const handleSignup = (e) => {
-    const { email, password } = e.target.elements;
+  /**
+   * Take values from form to attempt a signup
+   * @param {Object} event
+   */
+  const handleSignup = (event) => {
+    const { email, password } = event.target.elements;
     signup(email.value, password.value);
     setModalState(modalStates.closed);
   };
 
+  /**
+   * Elements specific to being logged in/authenticated
+   */
   const UserElements = () => {
     if (currentUser) {
       return (

--- a/src/components/templates/AddStory.js
+++ b/src/components/templates/AddStory.js
@@ -1,31 +1,67 @@
-import React from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import Modal from '../organisms/Modal';
 
-const AddStory = () => {
-  console.log('blah');
+const AddStory = ({ toggleModal }) => {
+  const [newStory, setNewStory] = useState({
+    title: localStorage.getItem('new-title') || '',
+    body: localStorage.getItem('new-body') || '',
+  });
+
+  const handleStoryContentChange = (e) => {
+    const { name, value } = e.target;
+    if (name === 'title' && value.length > 75) return;
+    if (name === 'body' && value.length > 240) return;
+
+    setNewStory((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    localStorage.setItem(`new-${name}`, value);
+  };
+
   return (
     <Modal
       title="Create New Story Link"
       subTitle="write the first lines of a brand new story"
-      confirmText="Login"
+      confirmText="Submit Story"
       canCancel
       submitHandler={() => {}}
-      cancelHandler={() => {}}
+      cancelHandler={() => toggleModal(false)}
     >
       <label htmlFor="story-add-title">
         <div>
           Title
         </div>
-        <input id="story-add-title" type="text" name="title" />
+        <input
+          id="story-add-title"
+          type="text"
+          name="title"
+          value={newStory.title}
+          onChange={handleStoryContentChange}
+        />
       </label>
       <label htmlFor="story-add-content">
         <div>
           Story
         </div>
-        <input id="story-add-content" type="password" name="content" />
+        <textarea
+          id="story-add-content"
+          name="body"
+          value={newStory.body}
+          onChange={handleStoryContentChange}
+        />
       </label>
+      <span>
+        Characters Left:
+        {240 - newStory.body.length}
+      </span>
     </Modal>
   );
 };
 
 export default AddStory;
+
+AddStory.propTypes = {
+  toggleModal: PropTypes.func.isRequired,
+};

--- a/src/components/templates/AddStory.js
+++ b/src/components/templates/AddStory.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Modal from '../organisms/Modal';
+
+const AddStory = () => {
+  console.log('blah');
+  return (
+    <Modal
+      title="Create New Story Link"
+      subTitle="write the first lines of a brand new story"
+      confirmText="Login"
+      canCancel
+      submitHandler={() => {}}
+      cancelHandler={() => {}}
+    >
+      <label htmlFor="story-add-title">
+        <div>
+          Title
+        </div>
+        <input id="story-add-title" type="text" name="title" />
+      </label>
+      <label htmlFor="story-add-content">
+        <div>
+          Story
+        </div>
+        <input id="story-add-content" type="password" name="content" />
+      </label>
+    </Modal>
+  );
+};
+
+export default AddStory;

--- a/src/components/templates/AddStory.js
+++ b/src/components/templates/AddStory.js
@@ -14,10 +14,10 @@ const AddStory = ({ toggleModal }) => {
 
   /**
    * Attempts to add story to firestore when user clicks submit
-   * @param {Object} e - event that is injected from onSubmit
+   * @param {Object} event
    */
-  const addNewStory = async (e) => {
-    e.preventDefault();
+  const addNewStory = async (event) => {
+    event.preventDefault();
     // don't attempt if no values in the form fields
     if (
       !newStory.title.trim()
@@ -43,10 +43,10 @@ const AddStory = ({ toggleModal }) => {
 
   /**
    * Saves values of field to localStorage whenever user changes field
-   * @param {Object} e - event that is injected from onSubmit
+   * @param {Object} event
    */
-  const handleStoryContentChange = (e) => {
-    const { name, value } = e.target;
+  const handleStoryContentChange = (event) => {
+    const { name, value } = event.target;
     if (name === 'title' && value.length > 75) return;
     if (name === 'content' && value.length > 240) return;
 

--- a/src/components/templates/AddStory.js
+++ b/src/components/templates/AddStory.js
@@ -1,23 +1,60 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '../organisms/Modal';
+import { db } from '../../firebase';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 const AddStory = ({ toggleModal }) => {
+  const { currentUser } = useAuthContext();
+  // pull values from localStorage if they exist
   const [newStory, setNewStory] = useState({
-    title: localStorage.getItem('new-title') || '',
-    body: localStorage.getItem('new-body') || '',
+    title: localStorage.getItem('story-title') || '',
+    content: localStorage.getItem('story-content') || '',
   });
 
+  /**
+   * Attempts to add story to firestore when user clicks submit
+   * @param {Object} e - event that is injected from onSubmit
+   */
+  const addNewStory = async (e) => {
+    e.preventDefault();
+    // don't attempt if no values in the form fields
+    if (
+      !newStory.title.trim()
+      || !newStory.content.trim()
+    ) return;
+
+    try {
+      await db.collection('links')
+        .add({
+          title: newStory.title,
+          content: newStory.content,
+          author: currentUser.displayName,
+        });
+      localStorage.removeItem('story-title');
+      localStorage.removeItem('story-content');
+    } catch (err) {
+      console.log(err);
+      throw err;
+    } finally {
+      toggleModal(false);
+    }
+  };
+
+  /**
+   * Saves values of field to localStorage whenever user changes field
+   * @param {Object} e - event that is injected from onSubmit
+   */
   const handleStoryContentChange = (e) => {
     const { name, value } = e.target;
     if (name === 'title' && value.length > 75) return;
-    if (name === 'body' && value.length > 240) return;
+    if (name === 'content' && value.length > 240) return;
 
     setNewStory((prev) => ({
       ...prev,
       [name]: value,
     }));
-    localStorage.setItem(`new-${name}`, value);
+    localStorage.setItem(`story-${name}`, value);
   };
 
   return (
@@ -26,7 +63,7 @@ const AddStory = ({ toggleModal }) => {
       subTitle="write the first lines of a brand new story"
       confirmText="Submit Story"
       canCancel
-      submitHandler={() => {}}
+      submitHandler={addNewStory}
       cancelHandler={() => toggleModal(false)}
     >
       <label htmlFor="story-add-title">
@@ -47,14 +84,14 @@ const AddStory = ({ toggleModal }) => {
         </div>
         <textarea
           id="story-add-content"
-          name="body"
-          value={newStory.body}
+          name="content"
+          value={newStory.content}
           onChange={handleStoryContentChange}
         />
       </label>
       <span>
         Characters Left:
-        {240 - newStory.body.length}
+        {240 - newStory.content.length}
       </span>
     </Modal>
   );

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,7 +2,7 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 
-const app = firebase.initializeApp({
+const config = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
   databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
@@ -11,14 +11,20 @@ const app = firebase.initializeApp({
   messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.REACT_APP_FIREBASE_APP_ID,
   measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
-});
+};
+
+const app = firebase.initializeApp(config);
 
 const auth = app.auth();
 const db = app.firestore();
 
 if (process.env.NODE_ENV === 'development') {
   auth.useEmulator('http://localhost:9099');
-  db.useEmulator('http://localhost', 8090);
+  db.useEmulator('http://localhost', 9098);
+  db.settings({
+    host: 'localhost:9098',
+    ssl: false,
+  });
 }
 
 export { auth, db };


### PR DESCRIPTION
## Linked Issues
Resolves #16 - _Create a story link submission modal_ 

## Solution
I've created an AddStory component that will render when clicking on the plus sign (+) button in the Nav when logged in. The modal allows you to type in a story and a title and submit. Story and title fields will remain persistent in your LocalStorage until you delete the text or submit your story.

## Reproduction Steps
This branch should meet all the requirements for the **Front End** portion of #1. 

## Follow-up PRs
- Create some sort of notification that our story was submitted successfully